### PR TITLE
Fixed some bugs when using custom prompt and multiprocess processing

### DIFF
--- a/vbench/__init__.py
+++ b/vbench/__init__.py
@@ -10,8 +10,7 @@ class VBench(object):
         self.device = device                        # cuda or cpu
         self.full_info_dir = full_info_dir          # full json file that VBench originally provides
         self.output_path = output_path              # output directory to save VBench results
-        if not os.path.exists(self.output_path):
-            os.makedirs(self.output_path, exist_ok=False)
+        os.makedirs(self.output_path, exist_ok=True)
 
     def build_full_dimension_list(self, ):
         return ["subject_consistency", "background_consistency", "aesthetic_quality", "imaging_quality", "object_class", "multiple_objects", "color", "spatial_relationship", "scene", "temporal_style", 'overall_consistency', "human_action", "temporal_flickering", "motion_smoothness", "dynamic_degree", "appearance_style"]        

--- a/vbench/overall_consistency.py
+++ b/vbench/overall_consistency.py
@@ -36,7 +36,7 @@ def overall_consistency(clip_model, video_dict, tokenizer, device, sample="middl
     image_transform = clip_transform(224)
     for info in tqdm(video_dict):
         query = info['prompt']
-        text = clip.tokenize([query]).to(device)
+        # text = clip.tokenize([query]).to(device)
         video_list = info['video_list']
         for video_path in video_list:
             cur_video = []

--- a/vbench/temporal_style.py
+++ b/vbench/temporal_style.py
@@ -36,7 +36,7 @@ def temporal_style(clip_model, video_dict, tokenizer, device, sample="middle"):
     image_transform = clip_transform(224)
     for info in tqdm(video_dict):
         query = info['prompt']
-        text = clip.tokenize([query]).to(device)
+        # text = clip.tokenize([query]).to(device)
         video_list = info['video_list']
         for video_path in video_list:
             cur_video = []


### PR DESCRIPTION
### Clip issues for custom prompt

Lines in the temporal_style & overall_consistency metrics file ([link1](https://github.com/Vchitect/VBench/blob/ee95430255e5506d5ef1113afb0bfb8d1fbb2970/vbench/temporal_style.py#L39), [link2](https://github.com/Vchitect/VBench/blob/ee95430255e5506d5ef1113afb0bfb8d1fbb2970/vbench/overall_consistency.py#L39)) will return an error for custom prompts longer than 77, and the variable `text` obtained by these lines will not be used in subsequent code, so the codes is commented to avoid errors and speed up metric calculation.


<details>

<summary>Error logs that may occur before modification:</summary>

```
Traceback (most recent call last):
  File "/data/VBench/evaluate.py", line 159, in <module>
    main()
  File "/data/VBench/evaluate.py", line 145, in main
    result_name = my_VBench.evaluate(
  File "/data/VBench/vbench/__init__.py", line 187, in evaluate
    results = evaluate_func(cur_full_info_path, self.device, submodules_list, **kwargs)
  File "/data/VBench/vbench/temporal_style.py", line 61, in compute_temporal_style
    all_results, video_results = temporal_style(viclip, video_dict, tokenizer, device)
  File "/data/VBench/vbench/temporal_style.py", line 39, in temporal_style
    text = clip.tokenize([query]).to(device)
  File "/data/anaconda3/envs/pixart/lib/python3.9/site-packages/clip/clip.py", line 234, in tokenize
    raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
RuntimeError: Input Drone view of waves crashing against the rugged cliffs along Big Sur’s garay point beach. The crashing blue waters create white-tipped waves, while the golden light of the setting sun illuminates the rocky shore. A small island with a lighthouse sits in the distance, and green shrubbery covers the cliff’s edge. The steep drop from the road down to the beach is a dramatic feat, with the cliff’s edges jutting out over the sea. This is a view that captures the raw beauty of the coast and the rugged landscape of the Pacific Coast Highway., masterpiece, best quality, highly detailed, good composition, extremely delicate and beautiful, 4k, 8k is too long for context length 77
```

</details>

### makedirs issue in VBench.__init__()
[The original code](https://github.com/Vchitect/VBench/blob/ee95430255e5506d5ef1113afb0bfb8d1fbb2970/vbench/__init__.py#L13) will cause an error when performing multiprocess processing.

For example, when two processes are running to calculate different metrics, process 1 will report an error when process 2 creates the `self.output_path` folder after process 1 successfully executes `if`. The revised code avoids this problem.