### PR TITLE
fix: handle zero-dimensional tensor

### DIFF
--- a/vbench/aesthetic_quality.py
+++ b/vbench/aesthetic_quality.py
@@ -64,6 +64,8 @@ def laion_aesthetic(aesthetic_model, clip_model, video_list, device):
                 image_feats = clip_model.encode_image(image_batch).to(torch.float32)
                 image_feats = F.normalize(image_feats, dim=-1, p=2)
                 aesthetic_scores = aesthetic_model(image_feats).squeeze()
+                if aesthetic_scores.dim() == 0:
+                    aesthetic_scores = aesthetic_scores.unsqueeze(0)
 
             aesthetic_scores_list.append(aesthetic_scores)
 


### PR DESCRIPTION
This commit fixes the following bug: 
When the number of frames in a video is batch_size + 1 (e.g. batch_size = 32, and the video has 65 frames), the last frame is processed separately as an image_batch. The returned aesthetic_scores.dim() == 0, which leads to an error in torch.cat(aesthetic_scores_list, dim=0) with the message: RuntimeError: zero-dimensional tensor (at position 2) cannot be concatenated.