### PR TITLE
Update aesthetic_quality.py

### DIFF
--- a/vbench/aesthetic_quality.py
+++ b/vbench/aesthetic_quality.py
@@ -63,7 +63,7 @@ def laion_aesthetic(aesthetic_model, clip_model, video_list, device):
             with torch.no_grad():
                 image_feats = clip_model.encode_image(image_batch).to(torch.float32)
                 image_feats = F.normalize(image_feats, dim=-1, p=2)
-                aesthetic_scores = aesthetic_model(image_feats).squeeze()
+                aesthetic_scores = aesthetic_model(image_feats).squeeze(dim=-1)
 
             aesthetic_scores_list.append(aesthetic_scores)
 


### PR DESCRIPTION
If batch size is 32 and video contains n*32+1 frames (e.g., 33), then the last iteration will consist of batch size ==1. In the current implementation, this gets squeezed and leads to a different number of dimensions compared to those with batch size > 1. Modify it to only squeeze across the last dimension, not the batch dim.