### PR TITLE
[Hardware] Add support for Huawei Ascend NPU

### DIFF
--- a/README-FAQ.md
+++ b/README-FAQ.md
@@ -33,3 +33,5 @@ A: Use [**VBench**](https://github.com/Vchitect/VBench?tab=readme-ov-file#usage)
 Use [**VBench-Long**](https://github.com/Vchitect/VBench/tree/master/vbench2_beta_long) for evaluating videos 5.0 seconds or longer (≥ 5.0s).
 Each benchmark is optimized for its respective video length to ensure fair and consistent evaluation.
 
+**Q: Does VBench support running on Huawei Ascend NPU?**<br>
+A: Yes. [Ascend Extension for PyTorch](https://github.com/Ascend/pytorch) develops `torch_npu` to adapt Ascend NPU to PyTorch so that developers who use the PyTorch can obtain powerful compute capabilities of Ascend AI Processors. Please install `torch` and `torch_npu` before installing vbench if you are using Ascend NPU devices. For more details, please refer to the official [installation guide](https://github.com/Ascend/pytorch#installation).

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ vbench evaluate --videos_path "sampled_videos/lavie/human_action" --dimension "h
 ##### Python
 ```python
 from vbench import VBench
-my_VBench = VBench(device, <path/to/VBench_full_info.json>, <path/to/save/dir>)
+my_VBench = VBench(<your_device: cpu/cuda/npu>, <path/to/VBench_full_info.json>, <path/to/save/dir>)
 my_VBench.evaluate(
     videos_path = <video_path>,
     name = <name>,

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ from setuptools import find_packages, setup
 import os
 
 def check_torch_version():
+    use_cuda = False
+
     try:
         import torch
         if not torch.cuda.is_available():
@@ -13,6 +15,8 @@ def check_torch_version():
         print(cuda_version)
         if cuda_version not in ["11.6", "11.7", "11.8", "12.1"]:
             raise RuntimeError(f"\033[91mUnsupported CUDA version: {cuda_version}. Please install PyTorch with 11.6<=CUDA<=12.1.\033[0m")
+        
+        use_cuda = True
     except:
         print("\033[93mPlease install torch and torchvision compiled with cuda 11.8 before installing vbench\033[0m")
         print("\033[93mFor CUDA 11.8, run:\033[0m")
@@ -21,7 +25,23 @@ def check_torch_version():
         print("\033[93m    pip install torch torchvision --index-url https://download.pytorch.org/whl/cu121\033[0m")
         print("\033[93mFor CUDA 11 with PyTorch < 2.0 run:\033[0m")
         print("\033[93m    pip install torch==1.13.1 torchvision==0.14.1\033[0m")
-        raise
+        print("\033[93mTry to use Ascend NPU.\033[0m")
+
+    if use_cuda:
+        return
+            
+    try:
+        import torch
+        import torch_npu
+        
+        if not torch.npu.is_available():
+            raise RuntimeError("\033[91mAscend NPU is not available.\033[0m")
+        
+        print("\033[92mUsing Ascend NPU to accelerate the process.\033[0m")
+    except:
+        print("\033[93mPlease install torch torch_npu and torchvision before installing vbench if you are using Ascend NPU devices.\033[0m")
+        print("\033[93mFor more details, please refer to the official installation guide: https://github.com/Ascend/pytorch#installation\033[0m")
+
 
 def fetch_readme():
     with open('README-pypi.md', encoding='utf-8') as f:

--- a/vbench/__init__.py
+++ b/vbench/__init__.py
@@ -14,6 +14,7 @@ class VBench(object):
         self.full_info_dir = full_info_dir          # full json file that VBench originally provides
         self.output_path = output_path              # output directory to save VBench results
         os.makedirs(self.output_path, exist_ok=True)
+        print0(f"Use device: {self.device}")
 
     def build_full_dimension_list(self, ):
         return ["subject_consistency", "background_consistency", "aesthetic_quality", "imaging_quality", "object_class", "multiple_objects", "color", "spatial_relationship", "scene", "temporal_style", 'overall_consistency', "human_action", "temporal_flickering", "motion_smoothness", "dynamic_degree", "appearance_style"]        


### PR DESCRIPTION
## Background

Ascend is a full-stack AI computing infrastructure for industry applications and services based on Huawei Ascend processors and software. For more information about Ascend, see [<u>Ascend Community</u>](https://www.hiascend.com/en/).

[<u>CANN</u>](https://www.hiascend.com/en/software/cann) (Compute Architecture of Neural Networks), developped by Huawei, is a heterogeneous computing architecture for AI.

Pytorch has officially announced [<u>support for Ascend NPU</u>](https://pytorch.org/blog/pytorch-2-1/) (through key PrivateUse1), please see the PrivateUse1 tutorial [<u>here</u>](https://pytorch.org/tutorials/advanced/privateuseone.html).

## Motivation

Currently, the number of developers using Ascend NPU for AI training and inferencing has been significantly increasing, especially in China. Therefore, I would like to add support for Ascend NPU backend for this project.

## Tests

> [!NOTE]
>
> To properly install CANN, see [<u>here</u>](https://ascend.github.io/docs/sources/ascend/quick_install.html) for more details.
> In addition, the version of `torch-npu` should match that of `torch`, see [<u>here</u>](https://github.com/Ascend/pytorch) for more details.

Example:

```python
from vbench import VBench

my_VBench = VBench("npu", "vbench/VBench_full_info.json", "outputs/evaluation_results")
my_VBench.evaluate(
    videos_path = "sampled_videos/lavie/human_action",
    name = "lavie_human_action",
    dimension_list = ["human_action"],
)
```

Outputs:

```bash
Use device: npu
Evaluation meta data saved to outputs/evaluation_results/lavie_human_action_full_info.json
/root/miniconda3/envs/vbench/lib/python3.10/site-packages/timm/models/layers/__init__.py:48: FutureWarning: Importing from timm.models.layers is deprecated, please import via timm.layers
  warnings.warn(f"Importing from {__name__} is deprecated, please import via timm.layers", FutureWarning)
/root/miniconda3/envs/vbench/lib/python3.10/site-packages/timm/models/registry.py:4: FutureWarning: Importing from timm.models.registry is deprecated, please import via timm.models
  warnings.warn(f"Importing from {__name__} is deprecated, please import via timm.models", FutureWarning)
/vllm-workspace/VBench/vbench/third_party/umt/models/modeling_finetune.py:348: UserWarning: Overwriting vit_large_patch16_224 in registry with vbench.third_party.umt.models.modeling_finetune.vit_large_patch16_224. This is because the name being registered conflicts with an existing name. Please check if this is not expected.
  def vit_large_patch16_224(pretrained=False, **kwargs):
cur_full_info_path: outputs/evaluation_results/lavie_human_action_full_info.json
Use checkpoint: False
Checkpoint number: 16
n_position: 3136
pre_n_position: 1568
Pretraining uses 8 frames, but current frame is 16
Interpolate the position embedding
Use learnable position embedding
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500/500 [02:05<00:00,  3.98it/s]
Evaluation results saved to outputs/evaluation_results/lavie_human_action_eval_results.json
```

Evaluation results:

```json
{
    "human_action": [
        0.964,
        [
            {
                "video_path": "sampled_videos/lavie/human_action/A person is riding a bike-0.mp4",
                "video_results": true,
                "cor_num_per_video": 1
            },
            // ...
        ]
    ]
}
```